### PR TITLE
Introduce TopK option for sparse vector embeddings except for ELSER

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextExpansionConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextExpansionConfig.java
@@ -34,6 +34,9 @@ public class TextExpansionConfig implements NlpConfig {
     public static final String EXPANSION_TYPE_ELSER = "elser";
     public static final String EXPANSION_TYPE_SPLADE = "splade";
 
+    public static final ParseField TOP_K = new ParseField("top_k");
+    public static final int UNSET_TOP_K_VALUE = -1;
+
     public static TextExpansionConfig fromXContentStrict(XContentParser parser) {
         return STRICT_PARSER.apply(parser, null);
     }
@@ -49,7 +52,7 @@ public class TextExpansionConfig implements NlpConfig {
         ConstructingObjectParser<TextExpansionConfig, Void> parser = new ConstructingObjectParser<>(
             NAME,
             ignoreUnknownFields,
-            a -> new TextExpansionConfig((VocabularyConfig) a[0], (Tokenization) a[1], (String) a[2], (String) a[3])
+            a -> new TextExpansionConfig((VocabularyConfig) a[0], (Tokenization) a[1], (String) a[2], (String) a[3], (Integer) a[4])
         );
         parser.declareObject(ConstructingObjectParser.optionalConstructorArg(), (p, c) -> {
             if (ignoreUnknownFields == false) {
@@ -67,6 +70,7 @@ public class TextExpansionConfig implements NlpConfig {
         );
         parser.declareString(ConstructingObjectParser.optionalConstructorArg(), RESULTS_FIELD);
         parser.declareString(ConstructingObjectParser.optionalConstructorArg(), EXPANSION_TYPE);
+        parser.declareInt(ConstructingObjectParser.optionalConstructorArg(), TOP_K);
         return parser;
     }
 
@@ -74,18 +78,21 @@ public class TextExpansionConfig implements NlpConfig {
     private final Tokenization tokenization;
     private final String resultsField;
     private final String expansionType;
+    private final int topK;
 
     public TextExpansionConfig(
         @Nullable VocabularyConfig vocabularyConfig,
         @Nullable Tokenization tokenization,
         @Nullable String resultsField,
-        @Nullable String expansionType
+        @Nullable String expansionType,
+        @Nullable Integer topK
     ) {
         this.vocabularyConfig = Optional.ofNullable(vocabularyConfig)
             .orElse(new VocabularyConfig(InferenceIndexConstants.nativeDefinitionStore()));
         this.tokenization = tokenization == null ? Tokenization.createDefault() : tokenization;
         this.resultsField = resultsField;
         this.expansionType = expansionType == null ? EXPANSION_TYPE_ELSER : expansionType;
+        this.topK = Optional.ofNullable(topK).orElse(UNSET_TOP_K_VALUE);
     }
 
     public TextExpansionConfig(StreamInput in) throws IOException {
@@ -94,8 +101,10 @@ public class TextExpansionConfig implements NlpConfig {
         resultsField = in.readOptionalString();
         if (in.getTransportVersion().onOrAfter(TransportVersions.ML_EXPANSION_TYPE)) {
             expansionType = in.readOptionalString();
+            topK = in.readInt();
         } else {
             expansionType = EXPANSION_TYPE_ELSER; // Default to ELSER
+            topK = UNSET_TOP_K_VALUE;
         }
     }
 
@@ -106,6 +115,7 @@ public class TextExpansionConfig implements NlpConfig {
         out.writeOptionalString(resultsField);
         if (out.getTransportVersion().onOrAfter(TransportVersions.ML_EXPANSION_TYPE)) {
             out.writeOptionalString(expansionType);
+            out.writeInt(topK);
         }
     }
 
@@ -120,6 +130,7 @@ public class TextExpansionConfig implements NlpConfig {
         if (expansionType != null) {
             builder.field(EXPANSION_TYPE.getPreferredName(), expansionType);
         }
+        builder.field(TOP_K.getPreferredName(), topK);
         builder.endObject();
         return builder;
     }
@@ -142,11 +153,12 @@ public class TextExpansionConfig implements NlpConfig {
                 vocabularyConfig,
                 configUpdate.tokenizationUpdate == null ? tokenization : configUpdate.tokenizationUpdate.apply(tokenization),
                 Optional.ofNullable(configUpdate.getResultsField()).orElse(resultsField),
-                Optional.ofNullable(configUpdate.getExpansionType()).orElse(expansionType)
+                Optional.ofNullable(configUpdate.getExpansionType()).orElse(expansionType),
+                configUpdate.getTopK()
             );
         } else if (update instanceof TokenizationConfigUpdate tokenizationUpdate) {
             var updatedTokenization = getTokenization().updateWindowSettings(tokenizationUpdate.getSpanSettings());
-            return new TextExpansionConfig(vocabularyConfig, updatedTokenization, resultsField, expansionType);
+            return new TextExpansionConfig(vocabularyConfig, updatedTokenization, resultsField, expansionType, topK);
         } else {
             throw incompatibleUpdateException(update.getName());
         }
@@ -174,6 +186,10 @@ public class TextExpansionConfig implements NlpConfig {
 
     public String getExpansionType() {
         return expansionType;
+    }
+
+    public int getTopK() {
+        return topK;
     }
 
     @Override
@@ -204,11 +220,12 @@ public class TextExpansionConfig implements NlpConfig {
         return Objects.equals(vocabularyConfig, that.vocabularyConfig)
             && Objects.equals(tokenization, that.tokenization)
             && Objects.equals(resultsField, that.resultsField)
-            && Objects.equals(expansionType, that.expansionType);
+            && Objects.equals(expansionType, that.expansionType)
+            && topK == that.topK;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(vocabularyConfig, tokenization, resultsField, expansionType);
+        return Objects.hash(vocabularyConfig, tokenization, resultsField, expansionType, topK);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextExpansionConfigUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextExpansionConfigUpdate.java
@@ -25,23 +25,26 @@ import java.util.Objects;
 import static org.elasticsearch.xpack.core.ml.inference.trainedmodel.NlpConfig.RESULTS_FIELD;
 import static org.elasticsearch.xpack.core.ml.inference.trainedmodel.NlpConfig.TOKENIZATION;
 import static org.elasticsearch.xpack.core.ml.inference.trainedmodel.TextExpansionConfig.EXPANSION_TYPE;
+import static org.elasticsearch.xpack.core.ml.inference.trainedmodel.TextExpansionConfig.TOP_K;
 
 public class TextExpansionConfigUpdate extends NlpConfigUpdate {
 
     public static final String NAME = TextExpansionConfig.NAME;
 
-    public static final TextExpansionConfigUpdate EMPTY_UPDATE = new TextExpansionConfigUpdate(null, null, null);
+    public static final TextExpansionConfigUpdate EMPTY_UPDATE = new TextExpansionConfigUpdate(null, null, TextExpansionConfig.UNSET_TOP_K_VALUE, null);
 
     public static TextExpansionConfigUpdate fromMap(Map<String, Object> map) {
         Map<String, Object> options = new HashMap<>(map);
         String resultsField = (String) options.remove(RESULTS_FIELD.getPreferredName());
         String expansionTypeField = (String) options.remove(EXPANSION_TYPE.getPreferredName());
+        Integer topKField = (Integer) options.remove(TOP_K.getPreferredName());
+        int topK = topKField == null ? TextExpansionConfig.UNSET_TOP_K_VALUE : topKField;
         TokenizationUpdate tokenizationUpdate = NlpConfigUpdate.tokenizationFromMap(options);
 
         if (options.isEmpty() == false) {
             throw ExceptionsHelper.badRequestException("Unrecognized fields {}.", options.keySet());
         }
-        return new TextExpansionConfigUpdate(resultsField, expansionTypeField, tokenizationUpdate);
+        return new TextExpansionConfigUpdate(resultsField, expansionTypeField, topK, tokenizationUpdate);
     }
 
     private static final ObjectParser<TextExpansionConfigUpdate.Builder, Void> STRICT_PARSER = createParser(false);
@@ -54,6 +57,7 @@ public class TextExpansionConfigUpdate extends NlpConfigUpdate {
         );
         parser.declareString(TextExpansionConfigUpdate.Builder::setResultsField, RESULTS_FIELD);
         parser.declareString(TextExpansionConfigUpdate.Builder::setExpansionType, EXPANSION_TYPE);
+        parser.declareInt(TextExpansionConfigUpdate.Builder::setTopK, TOP_K);
         parser.declareNamedObject(
             TextExpansionConfigUpdate.Builder::setTokenizationUpdate,
             (p, c, n) -> p.namedObject(TokenizationUpdate.class, n, lenient),
@@ -68,17 +72,20 @@ public class TextExpansionConfigUpdate extends NlpConfigUpdate {
 
     private final String resultsField;
     private final String expansionType;
+    private final int topK;
 
-    public TextExpansionConfigUpdate(String resultsField, String expansionType, TokenizationUpdate tokenizationUpdate) {
+    public TextExpansionConfigUpdate(String resultsField, String expansionType, int topK, TokenizationUpdate tokenizationUpdate) {
         super(tokenizationUpdate);
         this.resultsField = resultsField;
         this.expansionType = expansionType;
+        this.topK = topK;
     }
 
     public TextExpansionConfigUpdate(StreamInput in) throws IOException {
         super(in);
         this.resultsField = in.readOptionalString();
         this.expansionType = in.readOptionalString();
+        this.topK = in.readVInt();
     }
 
     @Override
@@ -86,6 +93,7 @@ public class TextExpansionConfigUpdate extends NlpConfigUpdate {
         super.writeTo(out);
         out.writeOptionalString(resultsField);
         out.writeOptionalString(expansionType);
+        out.writeVInt(topK);
     }
 
     @Override
@@ -96,6 +104,7 @@ public class TextExpansionConfigUpdate extends NlpConfigUpdate {
         if (expansionType != null) {
             builder.field(EXPANSION_TYPE.getPreferredName(), expansionType);
         }
+        builder.field(TOP_K.getPreferredName(), topK);
         return builder;
     }
 
@@ -123,6 +132,10 @@ public class TextExpansionConfigUpdate extends NlpConfigUpdate {
         return expansionType;
     }
 
+    public int getTopK() {
+        return topK;
+    }
+
     @Override
     public InferenceConfigUpdate.Builder<? extends InferenceConfigUpdate.Builder<?, ?>, ? extends InferenceConfigUpdate> newBuilder() {
         return new TextExpansionConfigUpdate.Builder().setResultsField(resultsField)
@@ -135,7 +148,9 @@ public class TextExpansionConfigUpdate extends NlpConfigUpdate {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         TextExpansionConfigUpdate that = (TextExpansionConfigUpdate) o;
-        return Objects.equals(resultsField, that.resultsField) && Objects.equals(tokenizationUpdate, that.tokenizationUpdate);
+        return Objects.equals(resultsField, that.resultsField) && Objects.equals(tokenizationUpdate, that.tokenizationUpdate)
+            && Objects.equals(expansionType, that.expansionType)
+            && topK == that.topK;
     }
 
     @Override
@@ -156,6 +171,7 @@ public class TextExpansionConfigUpdate extends NlpConfigUpdate {
     public static class Builder implements InferenceConfigUpdate.Builder<TextExpansionConfigUpdate.Builder, TextExpansionConfigUpdate> {
         private String resultsField;
         private String expansionType;
+        private int topK;
         private TokenizationUpdate tokenizationUpdate;
 
         @Override
@@ -169,6 +185,11 @@ public class TextExpansionConfigUpdate extends NlpConfigUpdate {
             return this;
         }
 
+        public TextExpansionConfigUpdate.Builder setTopK(int topK) {
+            this.topK = topK;
+            return this;
+        }
+
         public TextExpansionConfigUpdate.Builder setTokenizationUpdate(TokenizationUpdate tokenizationUpdate) {
             this.tokenizationUpdate = tokenizationUpdate;
             return this;
@@ -176,7 +197,7 @@ public class TextExpansionConfigUpdate extends NlpConfigUpdate {
 
         @Override
         public TextExpansionConfigUpdate build() {
-            return new TextExpansionConfigUpdate(resultsField, expansionType, tokenizationUpdate);
+            return new TextExpansionConfigUpdate(resultsField, expansionType, topK, tokenizationUpdate);
         }
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextExpansionConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextExpansionConfigTests.java
@@ -31,20 +31,24 @@ public class TextExpansionConfigTests extends InferenceConfigItemTestCase<TextEx
             randomBoolean() ? null : VocabularyConfigTests.createRandom(),
             randomBoolean() ? null : tokenization,
             randomBoolean() ? null : randomAlphaOfLength(5),
-            randomFrom(TextExpansionConfig.EXPANSION_TYPE_ELSER, TextExpansionConfig.EXPANSION_TYPE_SPLADE)
+            randomFrom(TextExpansionConfig.EXPANSION_TYPE_ELSER, TextExpansionConfig.EXPANSION_TYPE_SPLADE),
+            randomIntBetween(-1, 10) // top_k can be -1 (unset) or a positive integer
         );
     }
 
     public static TextExpansionConfig mutateForVersion(TextExpansionConfig instance, TransportVersion version) {
         String expansionType = instance.getExpansionType();
+        int topK = instance.getTopK();
         if (version.before(TransportVersions.ML_EXPANSION_TYPE)) {
             expansionType = null;
+            topK = TextExpansionConfig.UNSET_TOP_K_VALUE; // top_k is not supported before this version
         }
         return new TextExpansionConfig(
             instance.getVocabularyConfig(),
             InferenceConfigTestScaffolding.mutateTokenizationForVersion(instance.getTokenization(), version),
             instance.getResultsField(),
-            expansionType
+            expansionType,
+            topK
         );
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextExpansionConfigUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextExpansionConfigUpdateTests.java
@@ -32,7 +32,7 @@ public class TextExpansionConfigUpdateTests extends AbstractNlpConfigUpdateTestC
 
     public static TextExpansionConfigUpdate mutateForVersion(TextExpansionConfigUpdate instance, TransportVersion version) {
         if (version.before(TransportVersions.V_8_1_0)) {
-            return new TextExpansionConfigUpdate(instance.getResultsField(), instance.getExpansionType(), null);
+            return new TextExpansionConfigUpdate(instance.getResultsField(), instance.getExpansionType(), instance.getTopK(), null);
         }
         return instance;
     }
@@ -67,11 +67,14 @@ public class TextExpansionConfigUpdateTests extends AbstractNlpConfigUpdateTestC
         TextExpansionConfigUpdate expected = new TextExpansionConfigUpdate(
             "ml-results",
             TextExpansionConfig.EXPANSION_TYPE_ELSER,
+            TextExpansionConfig.UNSET_TOP_K_VALUE,
             expectedTokenization
         );
         Map<String, Object> config = new HashMap<>() {
             {
                 put(NlpConfig.RESULTS_FIELD.getPreferredName(), "ml-results");
+                put(TextExpansionConfig.EXPANSION_TYPE.getPreferredName(), TextExpansionConfig.EXPANSION_TYPE_ELSER);
+                put(TextExpansionConfig.TOP_K.getPreferredName(), TextExpansionConfig.UNSET_TOP_K_VALUE);
             }
         };
         return Tuple.tuple(config, expected);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/NlpHelpers.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/NlpHelpers.java
@@ -9,7 +9,9 @@ package org.elasticsearch.xpack.ml.inference.nlp;
 
 import org.elasticsearch.search.aggregations.pipeline.MovingFunctions;
 
+import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Objects;
 import java.util.PriorityQueue;
 
@@ -105,6 +107,30 @@ public final class NlpHelpers {
             result[i] = minHeap.poll();
         }
         return result;
+    }
+
+    static <T> List<T> topK(int k, List<T> list, Comparator<T> comparator) {
+        if (k < 0 || k > list.size()) {
+            k = list.size();
+        }
+
+        PriorityQueue<T> minHeap = new PriorityQueue<>(k, comparator);
+        // initialise with the first k values
+        for (int i = 0; i < k; i++) {
+            minHeap.add(list.get(i));
+        }
+
+        T minValue = minHeap.peek();
+        for (int i = k; i < list.size(); i++) {
+            if (comparator.compare(list.get(i), minValue) > 0) {
+                minHeap.poll();
+                minHeap.add(list.get(i));
+                minValue = minHeap.peek();
+            }
+        }
+        return minHeap.stream()
+            .sorted(comparator.reversed())
+            .toList();
     }
 
     /**

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/TextExpansionProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/TextExpansionProcessor.java
@@ -18,6 +18,7 @@ import org.elasticsearch.xpack.ml.inference.nlp.tokenizers.TokenizationResult;
 import org.elasticsearch.xpack.ml.inference.pytorch.results.PyTorchInferenceResult;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -56,13 +57,15 @@ public class TextExpansionProcessor extends NlpTask.Processor {
 
     @Override
     public NlpTask.ResultProcessor getResultProcessor(NlpConfig config) {
+        TextExpansionConfig textExpansionConfig = ((TextExpansionConfig) config);
         return (tokenization, pyTorchResult, chunkResults) -> processResult(
             tokenization,
             pyTorchResult,
             replacementVocab,
             config.getResultsField(),
             chunkResults,
-            ((TextExpansionConfig) config).getExpansionType()
+            textExpansionConfig.getExpansionType(),
+            textExpansionConfig.getTopK()
         );
     }
 
@@ -72,7 +75,8 @@ public class TextExpansionProcessor extends NlpTask.Processor {
         Map<Integer, String> replacementVocab,
         String resultsField,
         boolean chunkResults,
-        String expansionType
+        String expansionType,
+        int topK
     ) {
         // SPLADE type expansion
         if (TextExpansionConfig.EXPANSION_TYPE_SPLADE.equals(expansionType)) {
@@ -83,7 +87,8 @@ public class TextExpansionProcessor extends NlpTask.Processor {
 
             // For SPLADE models, the second dimension of the inference result is for each token in the input.
             var weightedTokens = spladeVectorToTokenWeights(pyTorchResult.getInferenceResult()[0], tokenization, replacementVocab);
-            weightedTokens.sort((t1, t2) -> Float.compare(t2.weight(), t1.weight()));
+            topK = topK == TextExpansionConfig.UNSET_TOP_K_VALUE ? weightedTokens.size() : topK;
+            weightedTokens = NlpHelpers.topK(topK, weightedTokens, Comparator.comparingDouble(WeightedToken::weight));
             return new TextExpansionResults(
                 Optional.ofNullable(resultsField).orElse(DEFAULT_RESULTS_FIELD),
                 weightedTokens,

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningInfoTransportActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningInfoTransportActionTests.java
@@ -973,7 +973,7 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
             .setTags(Collections.singletonList("prepackaged"))
             .setModelSize(1000)
             .setEstimatedOperations(2000)
-            .setInferenceConfig(new TextExpansionConfig(null, null, null, null))
+            .setInferenceConfig(new TextExpansionConfig(null, null, null, null, -1))
             .build();
         givenTrainedModels(Arrays.asList(trainedModel1, trainedModel2, trainedModel3, trainedModel4));
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/NlpHelpersTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/NlpHelpersTests.java
@@ -10,6 +10,8 @@ package org.elasticsearch.xpack.ml.inference.nlp;
 import org.elasticsearch.search.aggregations.pipeline.MovingFunctions;
 import org.elasticsearch.test.ESTestCase;
 
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -117,6 +119,42 @@ public class NlpHelpersTests extends ESTestCase {
         assertEquals(2, scoreAndIndices[1].index);
         assertEquals(0, scoreAndIndices[2].index);
         assertEquals(1, scoreAndIndices[3].index);
+    }
+
+    public void testTopK_List() {
+        var list = new ArrayList<Double>(List.of(1.0, 0.0, 2.0, 8.0, 9.0, 4.2, 4.2, 3.0));
+
+        // Test with k = 3
+        var result_k3 = NlpHelpers.topK(3, list, Comparator.comparingDouble(Double::doubleValue));
+        assertEquals(3, result_k3.size());
+        assertEquals(9.0, result_k3.get(0), 0.001);
+        assertEquals(8.0, result_k3.get(1), 0.001);
+        assertEquals(4.2, result_k3.get(2), 0.001);
+        assertEquals(8, list.size()); // original list should not be modified
+
+        // Test with k = -1 (Non-filtered)
+        var result_kMinus = NlpHelpers.topK(-1, list, Comparator.comparingDouble(Double::doubleValue));
+        assertEquals(8, result_kMinus.size());
+        assertEquals(9.0, result_kMinus.get(0), 0.001);
+        assertEquals(8.0, result_kMinus.get(1), 0.001);
+        assertEquals(4.2, result_kMinus.get(2), 0.001);
+        assertEquals(4.2, result_kMinus.get(3), 0.001);
+        assertEquals(3.0, result_kMinus.get(4), 0.001);
+        assertEquals(2.0, result_kMinus.get(5), 0.001);
+        assertEquals(1.0, result_kMinus.get(6), 0.001);
+        assertEquals(0.0, result_kMinus.get(7), 0.001);
+
+        // Test with k = 8 (k = size of the list, Non-filtered)
+        var result_k8 = NlpHelpers.topK(9, list, Comparator.comparingDouble(Double::doubleValue));
+        assertEquals(8, result_kMinus.size());
+        assertEquals(9.0, result_kMinus.get(0), 0.001);
+        assertEquals(8.0, result_kMinus.get(1), 0.001);
+        assertEquals(4.2, result_kMinus.get(2), 0.001);
+        assertEquals(4.2, result_kMinus.get(3), 0.001);
+        assertEquals(3.0, result_kMinus.get(4), 0.001);
+        assertEquals(2.0, result_kMinus.get(5), 0.001);
+        assertEquals(1.0, result_kMinus.get(6), 0.001);
+        assertEquals(0.0, result_kMinus.get(7), 0.001);
     }
 
     public void testSpladeSaturation() {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/TextEmbeddingProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/TextEmbeddingProcessorTests.java
@@ -92,7 +92,8 @@ public class TextEmbeddingProcessorTests extends ESTestCase {
                 Map.of(),
                 "foo",
                 true,
-                TextExpansionConfig.EXPANSION_TYPE_ELSER
+                TextExpansionConfig.EXPANSION_TYPE_ELSER,
+                TextExpansionConfig.UNSET_TOP_K_VALUE
             );
             assertThat(inferenceResult, instanceOf(MlChunkedTextExpansionResults.class));
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/TextExpansionProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/TextExpansionProcessorTests.java
@@ -57,7 +57,8 @@ public class TextExpansionProcessorTests extends ESTestCase {
             Map.of(),
             "foo",
             false,
-            TextExpansionConfig.EXPANSION_TYPE_ELSER
+            TextExpansionConfig.EXPANSION_TYPE_ELSER,
+            TextExpansionConfig.UNSET_TOP_K_VALUE
         );
         assertThat(inferenceResult, instanceOf(TextExpansionResults.class));
         var results = (TextExpansionResults) inferenceResult;
@@ -82,7 +83,8 @@ public class TextExpansionProcessorTests extends ESTestCase {
             Map.of(),
             "foo",
             false,
-            TextExpansionConfig.EXPANSION_TYPE_SPLADE
+            TextExpansionConfig.EXPANSION_TYPE_SPLADE,
+            TextExpansionConfig.UNSET_TOP_K_VALUE
         );
         assertThat(inferenceResult, instanceOf(TextExpansionResults.class));
         var results = (TextExpansionResults) inferenceResult;
@@ -96,6 +98,31 @@ public class TextExpansionProcessorTests extends ESTestCase {
         assertEquals(new WeightedToken("b", (float) NlpHelpers.spladeSaturation(1.0)), weightedTokens.get(3));
     }
 
+    public void testProcessResultForSplade_top2() {
+        double[][][] pytorchResult = new double[][][] {
+            { { 0.0, 1.0, 1.0, 3.0, 0.0, -1.0, 0.0 }, { 0.0, 0.0, 2.0, 3.0, 3.0, -2.0, 0.0 }, { 0.0, 0.0, 0.0, 0.0, 4.0, -3.0, 0.0 } } };
+
+        TokenizationResult tokenizationResult = new BertTokenizationResult(List.of("a", "b", "c", "d", "e", "f", "g"), List.of(), 0);
+
+        var inferenceResult = TextExpansionProcessor.processResult(
+            tokenizationResult,
+            new PyTorchInferenceResult(pytorchResult),
+            Map.of(),
+            "foo",
+            false,
+            TextExpansionConfig.EXPANSION_TYPE_SPLADE,
+            2
+        );
+        assertThat(inferenceResult, instanceOf(TextExpansionResults.class));
+        var results = (TextExpansionResults) inferenceResult;
+        assertEquals("foo", results.getResultsField());
+
+        var weightedTokens = results.getWeightedTokens();
+        assertThat(weightedTokens, hasSize(2));
+        assertEquals(new WeightedToken("e", (float) NlpHelpers.spladeSaturation(4.0)), weightedTokens.get(0));
+        assertEquals(new WeightedToken("d", (float) NlpHelpers.spladeSaturation(3.0)), weightedTokens.get(1));
+    }
+
     public void testSanitiseVocab() {
         double[][][] pytorchResult = new double[][][] { { { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 } } };
 
@@ -107,7 +134,8 @@ public class TextExpansionProcessorTests extends ESTestCase {
             Map.of(4, "XXX", 3, "YYY"),
             "foo",
             false,
-            TextExpansionConfig.EXPANSION_TYPE_ELSER
+            TextExpansionConfig.EXPANSION_TYPE_ELSER,
+            TextExpansionConfig.UNSET_TOP_K_VALUE
         );
         assertThat(inferenceResult, instanceOf(TextExpansionResults.class));
         var results = (TextExpansionResults) inferenceResult;
@@ -135,7 +163,7 @@ public class TextExpansionProcessorTests extends ESTestCase {
         var processor = new TextExpansionProcessor(
             BertTokenizer.builder(vocab, new BertTokenization(null, false, null, Tokenization.Truncate.NONE, -1)).build()
         );
-        var resultProcessor = processor.getResultProcessor(new TextExpansionConfig(null, null, null, null));
+        var resultProcessor = processor.getResultProcessor(new TextExpansionConfig(null, null, null, TextExpansionConfig.EXPANSION_TYPE_ELSER, TextExpansionConfig.UNSET_TOP_K_VALUE));
 
         var pytorchResult = new PyTorchInferenceResult(new double[][][] { { { 1.0, 2.0, 3.0, 4.0, 5.0 } } });
         TokenizationResult tokenizationResult = new BertTokenizationResult(vocab, List.of(), 0);
@@ -170,7 +198,8 @@ public class TextExpansionProcessorTests extends ESTestCase {
                 Map.of(),
                 "foo",
                 true,
-                TextExpansionConfig.EXPANSION_TYPE_ELSER
+                TextExpansionConfig.EXPANSION_TYPE_ELSER,
+                TextExpansionConfig.UNSET_TOP_K_VALUE
             );
             assertThat(inferenceResult, instanceOf(MlChunkedTextExpansionResults.class));
 
@@ -201,7 +230,8 @@ public class TextExpansionProcessorTests extends ESTestCase {
                 Map.of(),
                 "foo",
                 true,
-                TextExpansionConfig.EXPANSION_TYPE_ELSER
+                TextExpansionConfig.EXPANSION_TYPE_ELSER,
+                TextExpansionConfig.UNSET_TOP_K_VALUE
             );
             assertThat(inferenceResult, instanceOf(MlChunkedTextExpansionResults.class));
 


### PR DESCRIPTION
This pull request introduces a new `top_k` parameter to the `TextExpansionConfig` and `TextExpansionConfigUpdate` classes, enhancing their functionality to support selecting the top K results in text expansion inference. It also includes utility methods and tests to handle this new parameter.

This top K should affect only for non-ELSER models, because expected behavior for chunked ELSER result is unclear.